### PR TITLE
Added OPENOCD_CMDS option to support J-Link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 OPENOCD           ?= openocd
 OPENOCD_INTERFACE ?= interface/stlink-v2.cfg
+OPENOCD_CMDS      ?=
 REV               ?= B
 PYTHON2           ?= python2
 # CFLAGS          += -fdiagnostics-color=auto
@@ -87,14 +88,14 @@ clean:
 	rm -f bin/lps-node-firmware.elf bin/lps-node-firmware.dfu bin/.map $(OBJS)
 
 flash:
-	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) -f $(OPENOCD_TARGET) -c init -c targets -c "reset halt" \
+	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) $(OPENOCD_CMDS) -f $(OPENOCD_TARGET) -c init -c targets -c "reset halt" \
 	           -c "flash write_image erase bin/lps-node-firmware.elf" -c "verify_image bin/lps-node-firmware.elf" -c "reset run" -c shutdown
 erase:
-	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) -f $(OPENOCD_TARGET) -c init -c targets -c "reset halt" \
+	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) $(OPENOCD_CMDS) -f $(OPENOCD_TARGET) -c init -c targets -c "reset halt" \
 	           -c "stm32f1x mass_erase 0" -c shutdown
 
 openocd:
-	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) -f $(OPENOCD_TARGET) -c init -c targets
+	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) $(OPENOCD_CMDS) -f $(OPENOCD_TARGET) -c init -c targets
 
 dfu:
 	dfu-util -d 0483:df11 -a 0 -D bin/lps-node-firmware.dfu -s :leave


### PR DESCRIPTION
Added the OPENOCD_CMDS parameter to the Makefile to allow flashing using a J-Link programmer with:

`make OPENOCD_INTERFACE=interface/jlink.cfg OPENOCD_CMDS='-c "transport select swd"' OPENOCD_TARGET=target/stm32f0x.cfg flash`

This also makes it consistent with crazyflie-firmware.